### PR TITLE
Optimize hex0-seed (405->334 bytes)

### DIFF
--- a/Development/hex0_AMD64.M1
+++ b/Development/hex0_AMD64.M1
@@ -14,20 +14,14 @@
 ## You should have received a copy of the GNU General Public License
 ## along with stage0.  If not, see <http://www.gnu.org/licenses/>.
 
-DEFINE ADDI32_to_R13 4981C5
-DEFINE ADDI32_to_RAX 4805
-DEFINE ADD_R14_to_RAX 4C01F0
 DEFINE ADD_RAX_R14 4C01F0
 DEFINE CALLI32 E8
-DEFINE CMPI32_R15 4981FF
-DEFINE CMPI32_RAX 483D
-DEFINE CMP_R15_Immediate8 4983FF
 DEFINE CMP_RAX_Immediate8 4883F8
 DEFINE COPY_R9_to_RDI 4C89CF
 DEFINE COPY_R10_to_RDI 4C89D7
-DEFINE COPY_RAX_to_R14 4989C6
 DEFINE COPY_RAX_to_R9 4989C1
 DEFINE COPY_RAX_to_R10 4989C2
+DEFINE COPY_RSP_to_RSI 4889E6
 DEFINE JE32 0F84
 DEFINE JE8 74
 DEFINE JGE8 7D
@@ -37,35 +31,32 @@ DEFINE JMP32 E9
 DEFINE JMP8 EB
 DEFINE JNE32 0F85
 DEFINE JNE8 75
-DEFINE LOAD32_Address_in_RAX_into_RAX 678B00
-DEFINE LOAD8_al_Absolute32 8A0425
-DEFINE LOADI32_R13 49C7C5
-DEFINE LOADI32_R14 49C7C6
-DEFINE LOADI32_R15 49C7C7
-DEFINE LOADI32_RAX 48C7C0
-DEFINE LOADI32_EAX B8
-DEFINE LOADI32_EDI BF
 DEFINE LOADI32_EDX BA
 DEFINE LOADI32_ESI BE
 DEFINE MOVE_R14_RAX 4989C6
-DEFINE MOVZBQ_RAX_AL 480FB6C0
-DEFINE NOT_R15 49F7D7
 DEFINE NULL 00000000
 DEFINE POP_RAX 58
+DEFINE POP_RBX 5B
 DEFINE POP_RDI 5F
+DEFINE POP_RDX 5A
+DEFINE POP_R15 415F
+DEFINE PUSH_-1 6AFF
+DEFINE PUSH_1 6A01
+DEFINE PUSH_2 6A02
+DEFINE PUSH_60 6A3C
+DEFINE PUSH_RAX 50
+DEFINE PUSH_RBX 53
 DEFINE RET C3
-DEFINE RETQ C3
-DEFINE SHL8_R14 49C1E6
-DEFINE SHL8_RAX 48C1E0
 DEFINE SHL_R14_Immediate8 49C1E6
-DEFINE STORE32_R13_to_Address_in_RAX 4C8928
-DEFINE STORE32_RAX_Absolute32 890425
-DEFINE STORE8_al_Absolute32 880425
-DEFINE SUBI8_from_RAX 4883E8
-DEFINE SUB_R13_from_RAX 4C29E8
 DEFINE SUB_RAX_Immediate8 4883E8
 DEFINE SYSCALL 0F05
 DEFINE TEST_RAX_RAX 4885C0
+DEFINE TEST_R15_R15 4D85FF
+DEFINE XOR_EAX_EAX 31C0
+DEFINE XOR_ESI_ESI 31F6
+DEFINE XOR_EDI_EDI 31FF
+DEFINE XOR_R14D_R14D 4531F6
+DEFINE XOR_R15D_R15D 4531FF
 
 # Where the ELF Header is going to hit
 # Simply jump to _start
@@ -74,23 +65,26 @@ DEFINE TEST_RAX_RAX 4885C0
 	POP_RAX                     # Get the number of arguments
 	POP_RDI                     # Get the program name
 	POP_RDI                     # Get the actual input name
-	LOADI32_ESI %0              # prepare read_only
-	LOADI32_EAX %2              # the syscall number for open()
+	XOR_ESI_ESI                 # prepare read_only, rsi = 0
+	PUSH_2                      # prepare syscall number
+	POP_RAX                     # the syscall number for open()
 	SYSCALL                     # Now open that damn file
 	COPY_RAX_to_R9              # Preserve the file pointer we were given
 
 	POP_RDI                     # Get the actual output name
 	LOADI32_ESI %577            # Prepare file as O_WRONLY|O_CREAT|O_TRUNC
 	LOADI32_EDX %448            # Prepare file as RWX for owner only (700 in octal)
-	LOADI32_EAX %2              # the syscall number for open()
+	PUSH_2                      # prepare syscall number
+	POP_RAX                     # the syscall number for open()
 	SYSCALL                     # Now open that damn file
 	COPY_RAX_to_R10             # Preserve the file pointer we were given
 
 	# Our flag for byte processing
-	LOADI32_R15 %-1
+	PUSH_-1
+	POP_R15                     # r15 = -1
 
 	# temp storage for the sum
-	LOADI32_R14 %0
+	XOR_R14D_R14D               # r14 = 0
 
 :loop
 	# Read a byte
@@ -100,16 +94,16 @@ DEFINE TEST_RAX_RAX 4885C0
 	CALLI32 %hex
 
 	# deal with -1 values
-	CMP_RAX_Immediate8 !0
+	TEST_RAX_RAX
 	JL8 !loop
 
 	# deal with toggle
-	CMP_R15_Immediate8 !0
+	TEST_R15_R15                # jump if r15 >= 0
 	JGE8 !print
 
 	# process first byte of pair
 	MOVE_R14_RAX
-	LOADI32_R15 %0
+	XOR_R15D_R15D               # r15 = 0
 	JMP8 !loop
 
 # process second byte of pair
@@ -117,10 +111,10 @@ DEFINE TEST_RAX_RAX 4885C0
 	# update the sum and store in output
 	SHL_R14_Immediate8 !4
 	ADD_RAX_R14
-	STORE8_al_Absolute32 &output
 
 	# flip the toggle
-	LOADI32_R15 %-1
+	PUSH_-1
+	POP_R15                     # r15 = -1
 
 	CALLI32 %write_byte
 
@@ -171,64 +165,63 @@ DEFINE TEST_RAX_RAX 4885C0
 	JNE8 !purge_comment
 
 	# Otherwise return -1
-	LOADI32_RAX %-1
-	RETQ
+	PUSH_-1
+	POP_RAX                     # rax = -1
+	RET
 
 :ascii_num
 	SUB_RAX_Immediate8 !48
-	RETQ
+	RET
 
 :ascii_low
 	SUB_RAX_Immediate8 !87
-	RETQ
+	RET
 
 :ascii_high
 	SUB_RAX_Immediate8 !55
-	RETQ
+	RET
 
 :ascii_other
-	LOADI32_RAX %-1
-	RETQ
+	PUSH_-1
+	POP_RAX                     # rax = -1
+	RET
 
 :Done
 	# program completed Successfully
-	LOADI32_EDI %0              # All is well
-	LOADI32_EAX %60             # put the exit syscall number in rax
+	XOR_EDI_EDI                 # All is well, rdi = 0
+	PUSH_60                     # sycall number for exit is 60
+	POP_RAX                     # put the exit syscall number in rax
 	SYSCALL                     # Call it a good day
 
+# Writes byte stored in al
 :write_byte
 	# Print our Hex
-	LOADI32_EDX %1              # set the size of chars we want
-	LOADI32_ESI &output         # What we are writing
+	PUSH_1                      # prepare to set rdx to 1
+	POP_RDX                     # set the size of chars we want
+	PUSH_RAX                    # Move output to stack
+	COPY_RSP_to_RSI             # What we are writing
 	COPY_R10_to_RDI             # Where are we writing to
-	LOADI32_EAX %1              # the syscall number for write
+	PUSH_1                      # prepare syscall number for write
+	POP_RAX                     # get the syscall number for write
 	SYSCALL                     # call the Kernel
+	POP_RBX                     # deallocate stack
 	RET
-
-# Where we are putting our output
-:output
-	# Reserve 4bytes of Zeros
-	NULL
 
 :read_byte
 	# Attempt to read 1 byte from STDIN
-	LOADI32_EDX %1              # set the size of chars we want
-	LOADI32_ESI &input          # Where to put it
+	PUSH_1                      # prepare to set rdx to 1
+	POP_RDX                     # set the size of chars we want
+	PUSH_RBX                    # allocate stack
+	COPY_RSP_to_RSI             # Where to put it
 	COPY_R9_to_RDI              # Where are we reading from
-	LOADI32_EAX %0              # the syscall number for read
+	XOR_EAX_EAX                 # the syscall number for read, rax = 0
 	SYSCALL                     # call the Kernel
 
 	TEST_RAX_RAX                # check what we got
 	JE8 !Done                   # Got EOF call it done
 
 	# load byte
-	LOAD8_al_Absolute32 &input  # load char
-	MOVZBQ_RAX_AL               # We have to zero extend it to use it
+	POP_RAX                     # load char
 	RET
-
-# Where we get our input
-:input
-	# Reserve 4bytes of Zeros
-	NULL
 
 :ELF_end

--- a/NASM/hex0_AMD64.S
+++ b/NASM/hex0_AMD64.S
@@ -24,23 +24,26 @@ _start:
 	pop rax                     ; Get the number of arguments
 	pop rdi                     ; Get the program name
 	pop rdi                     ; Get the actual input name
-	mov rsi, 0                  ; prepare read_only
-	mov rax, 2                  ; the syscall number for open()
+	xor esi, esi                ; prepare read_only, rsi = 0
+	push 2                      ; prepare syscall number
+	pop rax                     ; the syscall number for open()
 	syscall                     ; Now open that damn file
 	mov r9, rax                 ; Preserve the file pointer we were given
 
 	pop rdi                     ; Get the actual output name
 	mov rsi, 577                ; Prepare file as O_WRONLY|O_CREAT|O_TRUNC
 	mov rdx, 448                ; Prepare file as RWX for owner only (700 in octal)
-	mov rax, 2                  ; the syscall number for open()
+	push 2                      ; prepare syscall number
+	pop rax                     ; the syscall number for open()
 	syscall                     ; Now open that damn file
 	mov r10, rax                ; Preserve the file pointer we were given
 
 	; Our flag for byte processing
-	mov r15, -1
+	push -1
+	pop r15                     ; r15 = -1
 
-	; temp storage for the sum
-	mov r14, 0
+	; tmp storage for the sum
+	xor r14d, r14d              ; r14 = 0
 
 loop:
 	; Read a byte
@@ -50,16 +53,16 @@ loop:
 	call hex
 
 	; Deal with -1 values
-	cmp rax, 0
+	test rax, rax
 	jl loop
 
 	; deal with toggle
-	cmp r15, 0
+	test r15, r15               ; jump if r15 >= 0
 	jge print
 
 	; process first byte of pair
 	mov r14, rax
-	mov r15, 0
+	xor r15d, r15d              ; r15 = 0
 	jmp loop
 
 ; process second byte of pair
@@ -67,10 +70,10 @@ print:
 	; update the sum and store in output
 	shl r14, 4
 	add rax, r14
-	mov [output], al
 
 	; flip the toggle
-	mov r15, -1
+	push -1
+	pop r15                     ; r15 = -1
 
 	call write_byte
 
@@ -121,7 +124,8 @@ purge_comment:
 	jne purge_comment
 
 	; Otherwise return -1
-	mov rax, -1
+	push -1
+	pop rax                     ; rax = -1
 	ret
 
 ascii_num:
@@ -137,49 +141,48 @@ ascii_high:
 	ret
 
 ascii_other:
-	mov rax, -1
+	push -1
+	pop rax                     ; rax = -1
 	ret
 
 Done:
 	; program completed Successfully
-	mov rdi, 0                  ; All is well
-	mov rax, 60                 ; put the exit syscall number in eax
+	xor edi, edi                ; All is well, rdi = 0
+	push 60                     ; sycall number for exit is 60
+	pop rax                     ; put the exit syscall number in eax
 	syscall                     ; Call it a good day
 
+; Writes byte stored in al
 write_byte:
 	; Print our Hex
-	mov rdx, 1                  ; set the size of chars we want
-	mov rsi, output             ; What we are writing
+	push 1                      ; prepare to set rdx to 1
+	pop rdx                     ; set the size of chars we want
+	push rax                    ; Move output to stack
+	mov rsi, rsp                ; What we are writing
 	mov rdi, r10                ; Where are we writing to
-	mov rax, 1                  ; the syscall number for write
+	push 1                      ; prepare syscall number for write
+	pop rax                     ; get the syscall number for write
 	syscall                     ; call the Kernel
+	pop rbx                     ; deallocate stack
 	ret
 
 Read_byte:
 	; Attempt to read 1 byte from STDIN
-	mov rdx,  1                 ; set the size of chars we want
-	mov rsi, input              ; Where to put it
+	push 1                      ; prepare to set rdx to 1
+	pop rdx                     ; set the size of chars we want
+	push rbx                    ; allocate stack
+	mov rsi, rsp                ; Where to put it
 	mov rdi, r9                 ; Where are we reading from
-	mov rax, 0                  ; the syscall number for read
+	xor eax, eax                ; the syscall number for read, rax = 0
 	syscall                     ; call the Kernel
 
 	test rax, rax               ; check what we got
 	je Done                     ; Got EOF call it done
 
 	; load byte
-	mov al, [input]             ; load char
-	movzx rax, al               ; We have to zero extend it to use it
+	pop rax                     ; load char
 	ret
 
 
 section .data
 ELF_end:
-; Where we are putting our output
-output:
-	; Reserve 4bytes of Zeros
-	dq 0
-
-; Where we get our input
-input:
-	; Reserve 4bytes of Zeros
-	dq 0

--- a/hex0_AMD64.hex0
+++ b/hex0_AMD64.hex0
@@ -1,5 +1,6 @@
 ### Copyright (C) 2016 Jeremiah Orians
 ### Copyright (C) 2017 Jan Nieuwenhuizen <janneke@gnu.org>
+### Copyright (C) 2022 Andrius Štikonas <andrius@stikonas.eu>
 ### This file is part of stage0.
 ###
 ### stage0 is free software: you can redistribute it and/or modify
@@ -59,8 +60,8 @@
 00 00 60 00 00 00 00 00 ## p_vaddr
 00 00 60 00 00 00 00 00 ## p_physaddr
 
-95 01 00 00 00 00 00 00 ## p_filesz
-95 01 00 00 00 00 00 00 ## p_memsz
+4E 01 00 00 00 00 00 00 ## p_filesz
+4E 01 00 00 00 00 00 00 ## p_memsz
 
 01 00 00 00 00 00 00 00 ## Required alignment
 
@@ -73,57 +74,60 @@
 	58                  ; POP_RAX         # Get the number of arguments
 	5F                  ; POP_RDI         # Get the program name
 	5F                  ; POP_RDI         # Get the actual input name
-	BE 00000000         ; LOADI32_ESI %0  # prepare read_only
-	B8 02000000         ; LOADI32_EAX %2  # the syscall number for open()
+	31F6                ; XOR_ESI_ESI     # prepare read_only, rsi = 0
+	6A02                ; PUSH_2          # prepare syscall number
+	58                  ; POP_RAX         # the syscall number for open()
 	0F05                ; SYSCALL         # Now open that damn file
 	4989C1              ; COPY_RAX_to_R9  # Preserve the file pointer we were given
 
 	5F                  ; POP_RDI         # Get the actual output name
 	BE 41020000         ; LOADI32_ESI %577 # Prepare file as O_WRONLY|O_CREAT|O_TRUNC
 	BA C0010000         ; LOADI32_EDX %448 # Prepare file as RWX for owner only (700 in octal)
-	B8 02000000         ; LOADI32_EAX %2  # the syscall number for open()
+	6A02                ; PUSH_2          # prepare syscall number
+	58                  ; POP_RAX         # the syscall number for open()
 	0F05                ; SYSCALL         # Now open that damn file
 	4989C2              ; COPY_RAX_to_R10 # Preserve the file pointer we were given
 
 	# Our flag for byte processing
-	49C7C7 FFFFFFFF     ; LOADI32_R15 %-1
+	6AFF                ; PUSH_-1
+	415F                ; POP_R15         # r15 = -1
 
 	# temp storage for the sum
-	49C7C6 00000000     ; LOADI32_R14 %0
+	4531F6              ; XOR_R14D_R14D   # r14 = 0
 
 #:loop
 	# Read a byte
-	E8 BA000000         ; CALLI32 %read_byte
+	E8 95000000         ; CALLI32 %read_byte
 
 	# process byte
-	E8 34000000         ; CALLI32 %hex
+	E8 24000000         ; CALLI32 %hex
 
 	# deal with -1 values
-	4883F8 00           ; CMP_RAX_Immediate8 !0
-	7C F0               ; JL8 !loop
+	4885C0              ; TEST_RAX_RAX
+	7C F1               ; JL8 !loop
 
 	# deal with toggle
-	4983FF 00           ; CMP_R15_Immediate8 !0
-	7D 0C               ; JGE8 !print
+	4D85FF              ; TEST_R15_R15    # jump if r15 >= 0
+	7D 08               ; JGE8 !print
 
 	# process first byte of pair
 	4989C6              ; MOVE_R14_RAX
-	49C7C7 00000000     ; LOADI32_R15 %0
-	EB DE               ; JMP8 !loop
+	4531FF              ; XOR_R15D_R15D   # r15 = 0
+	EB E4               ; JMP8 !loop
 
 # process second byte of pair
 #:print
 	# update the sum and store in output
 	49C1E6 04           ; SHL_R14_Immediate8 !4
 	4C01F0              ; ADD_RAX_R14
-	880425 68016000     ; STORE8_al_Absolute32 &output
 
 	# flip the toggle
-	49C7C7 FFFFFFFF     ; LOADI32_R15 %-1
+	6AFF                ; PUSH_-1
+	415F                ; POP_R15         # r15 = -1
 
-	E8 6A000000         ; CALLI32 %write_byte
+	E8 5D000000         ; CALLI32 %write_byte
 
-	EB C2               ; JMP8 !loop
+	EB D2               ; JMP8 !loop
 
 #:hex
 	# Purge Comment Lines (#)
@@ -136,99 +140,97 @@
 
 	# deal all ascii less than '0'
 	4883F8 30           ; CMP_RAX_Immediate8 !48
-	7C 42               ; JL8 !ascii_other
+	7C 3E               ; JL8 !ascii_other
 
 	# deal with 0-9
 	4883F8 3A           ; CMP_RAX_Immediate8 !58
-	7C 2D               ; JL8 !ascii_num
+	7C 29               ; JL8 !ascii_num
 
 	# deal with all ascii less than 'A'
 	4883F8 41           ; CMP_RAX_Immediate8 !65
-	7C 36               ; JL8 !ascii_other
+	7C 32               ; JL8 !ascii_other
 
 	# deal with 'A'-'F'
 	4883F8 47           ; CMP_RAX_Immediate8 !71
-	7C 2B               ; JL8 !ascii_high
+	7C 27               ; JL8 !ascii_high
 
 	# deal with all ascii less than 'a'
 	4883F8 61           ; CMP_RAX_Immediate8 !97
-	7C 2A               ; JL8 !ascii_other
+	7C 26               ; JL8 !ascii_other
 
 	#deal with 'a'-'f'
 	4883F8 67           ; CMP_RAX_Immediate8 !103
-	7C 1A               ; JL8 !ascii_low
+	7C 16               ; JL8 !ascii_low
 
 	# The rest that remains needs to be ignored
-	EB 22               ; JMP8 !ascii_other
+	EB 1E               ; JMP8 !ascii_other
 
 #:purge_comment
 	# Read a byte
-	E8 4A000000         ; CALLI32 %read_byte
+	E8 35000000         ; CALLI32 %read_byte
 
 	# Loop if not LF
 	4883F8 0A           ; CMP_RAX_Immediate8 !10
 	75 F5               ; JNE8 !purge_comment
 
-
 	# Otherwise return -1
-	48C7C0 FFFFFFFF     ; LOADI32_RAX %-1
-	C3                  ; RETQ
+	6AFF                ; PUSH_-1
+	58                  ; POP_RAX         # rax = -1
+	C3                  ; RET
 
 #:ascii_num
 	4883E8 30           ; SUB_RAX_Immediate8 !48
-	C3                  ; RETQ
+	C3                  ; RET
 
 #:ascii_low
 	4883E8 57           ; SUB_RAX_Immediate8 !87
-	C3                  ; RETQ
+	C3                  ; RET
 
 #:ascii_high
 	4883E8 37           ; SUB_RAX_Immediate8 !55
-	C3                  ; RETQ
+	C3                  ; RET
 
 #:ascii_other
-	48C7C0 FFFFFFFF     ; LOADI32_RAX %-1
-	C3                  ; RETQ
+	6AFF                ; PUSH_-1
+	58                  ; POP_RAX         # rax = -1
+	C3                  ; RET
 
 #:Done
 	# program completed Successfully
-	BF 00000000         ; LOADI32_EDI %0  # All is well
-	B8 3C000000         ; LOADI32_RAX %60 # put the exit syscall number in rax
+	31FF                ; XOR_EDI_EDI     # All is well, rdi = 0
+	6A3C                ; PUSH_60         # sycall number for exit is 60
+	58                  ; POP_RAX         # put the exit syscall number in rax
 	0F05                ; SYSCALL         # Call it a good day
 
+# Writes byte stored in al
 #:write_byte
 	# Print our Hex
-	BA 01000000         ; LOADI32_EDX %1  # set the size of chars we want
-	BE 68016000         ; LOADI32_ESI %output # What we are writing
+	6A01                ; PUSH_1          # prepare to set rdx to 1
+	5A                  ; POP_RDX         # set the size of chars we want
+	50                  ; PUSH_RAX        # Move output to stack
+	4889E6              ; COPY_RSP_to_RSI # What we are writing
 	4C89D7              ; COPY_R10_to_RDI # Where are we writing to
-	B8 01000000         ; LOADI32_EAX %1  # the syscall number for write
+	6A01                ; PUSH_1          # prepare syscall number for write
+	58                  ; POP_RAX         # get the syscall number for write
 	0F05                ; SYSCALL         # call the Kernel
+	5B                  ; POP_RBX         # deallocate stack
 	C3                  ; RET
-
-# Where we are putting our output
-#:output
-	# Reserve 4bytes of Zeros
-	00000000            ; NULL
 
 #:read_byte
 	# Attempt to read 1 byte from STDIN
-	BA 01000000         ; LOADI32_EDX %1  # set the size of chars we want
-	BE 91016000         ; LOADI32_ESI &input # Where to put it
+	6A01                ; PUSH_1          # prepare to set rdx to 1
+	5A                  ; POP_RDX         # set the size of chars we want
+	53                  ; PUSH_RBX        # allocate stack
+	4889E6              ; COPY_RSP_to_RSI # Where to put it
 	4C89CF              ; COPY_R9_to_RDI  # Where are we reading from
-	B8 00000000         ; LOADI32_EAX %0  # the syscall number for read
+	31C0                ; XOR_EAX_EAX     # the syscall number for read
 	0F05                ; SYSCALL         # call the Kernel
 
 	4885C0              ; TEST_RAX_RAX    # check what we got
-	74 C2               ; JE8 !Done       # Got EOF call it done
+	74 D5               ; JE8 !Done       # Got EOF call it done
 
 	# load byte
-	8A0425 91016000     ; LOAD8_al_Absolute32 &input # load char
-	480FB6C0            ; MOVZBQ_RAX_AL   # We have to zero extend it to use it
+	58                  ; POP_RAX         # load char
 	C3                  ; RET
-
-# Where we get our input
-#:input
-	# Reserve 4bytes of Zeros
-	00000000            ; NULL
 
 #:ELF_end


### PR DESCRIPTION
* Use push/pop rather than mov for loading small immediates
* Use xor reg, reg instead of mov reg, 0
* Use test reg, reg instead of cmp reg, 0 (this was already
  used in some places)
* Use stack for i/o buffer instead of global variables.