### PR TITLE
Port hex0 optimizations from x86 to amd64.

### DIFF
--- a/Development/hex0_AMD64.M1
+++ b/Development/hex0_AMD64.M1
@@ -1,4 +1,5 @@
 ## Copyright (C) 2017 Jeremiah Orians
+## Copyright (C) 2022 Andrius Štikonas <andrius@stikonas.eu>
 ## This file is part of stage0.
 ##
 ## stage0 is free software: you can redistribute it and/or modify
@@ -14,49 +15,45 @@
 ## You should have received a copy of the GNU General Public License
 ## along with stage0.  If not, see <http://www.gnu.org/licenses/>.
 
-DEFINE ADD_RAX_R14 4C01F0
+DEFINE ADD_EAX_EBP 01E8
 DEFINE CALLI32 E8
-DEFINE CMP_RAX_Immediate8 4883F8
+DEFINE CMPI8_AL 3C
+DEFINE COPY_EBP_EAX 89C5
 DEFINE COPY_R9_to_RDI 4C89CF
 DEFINE COPY_R10_to_RDI 4C89D7
 DEFINE COPY_RAX_to_R9 4989C1
 DEFINE COPY_RAX_to_R10 4989C2
 DEFINE COPY_RSP_to_RSI 4889E6
+DEFINE DEC_EBX FFCB
 DEFINE JE32 0F84
 DEFINE JE8 74
 DEFINE JGE8 7D
 DEFINE JL32 0F8C
 DEFINE JL8 7C
-DEFINE JMP32 E9
 DEFINE JMP8 EB
-DEFINE JNE32 0F85
 DEFINE JNE8 75
-DEFINE LOADI32_EDX BA
-DEFINE LOADI32_ESI BE
-DEFINE MOVE_R14_RAX 4989C6
+DEFINE LOADI16_DX 66BA
+DEFINE LOADI16_SI 66BE
 DEFINE NULL 00000000
 DEFINE POP_RAX 58
 DEFINE POP_RBX 5B
 DEFINE POP_RDI 5F
 DEFINE POP_RDX 5A
-DEFINE POP_R15 415F
-DEFINE PUSH_-1 6AFF
-DEFINE PUSH_1 6A01
-DEFINE PUSH_2 6A02
-DEFINE PUSH_60 6A3C
+DEFINE PUSH 6A
 DEFINE PUSH_RAX 50
 DEFINE PUSH_RBX 53
+DEFINE PUSH_RDI 57
 DEFINE RET C3
-DEFINE SHL_R14_Immediate8 49C1E6
-DEFINE SUB_RAX_Immediate8 4883E8
+DEFINE SHL_EBP_Immediate8 C1E5
+DEFINE SUBI8_AL 2C
 DEFINE SYSCALL 0F05
-DEFINE TEST_RAX_RAX 4885C0
-DEFINE TEST_R15_R15 4D85FF
+DEFINE TEST_EBX_EBX 85DB
+DEFINE TEST_EAX_EAX 85C0
 DEFINE XOR_EAX_EAX 31C0
-DEFINE XOR_ESI_ESI 31F6
+DEFINE XOR_EBX_EBX 31DB
+DEFINE XOR_EBP_EBP 31ED
 DEFINE XOR_EDI_EDI 31FF
-DEFINE XOR_R14D_R14D 4531F6
-DEFINE XOR_R15D_R15D 4531FF
+DEFINE XOR_ESI_ESI 31F6
 
 # Where the ELF Header is going to hit
 # Simply jump to _start
@@ -66,25 +63,25 @@ DEFINE XOR_R15D_R15D 4531FF
 	POP_RDI                     # Get the program name
 	POP_RDI                     # Get the actual input name
 	XOR_ESI_ESI                 # prepare read_only, rsi = 0
-	PUSH_2                      # prepare syscall number
+	PUSH !2                     # prepare syscall number
 	POP_RAX                     # the syscall number for open()
 	SYSCALL                     # Now open that damn file
 	COPY_RAX_to_R9              # Preserve the file pointer we were given
 
 	POP_RDI                     # Get the actual output name
-	LOADI32_ESI %577            # Prepare file as O_WRONLY|O_CREAT|O_TRUNC
-	LOADI32_EDX %448            # Prepare file as RWX for owner only (700 in octal)
-	PUSH_2                      # prepare syscall number
+	LOADI16_SI @577             # Prepare file as O_WRONLY|O_CREAT|O_TRUNC
+	LOADI16_DX @448             # Prepare file as RWX for owner only (700 in octal)
+	PUSH !2                     # prepare syscall number
 	POP_RAX                     # the syscall number for open()
 	SYSCALL                     # Now open that damn file
 	COPY_RAX_to_R10             # Preserve the file pointer we were given
 
 	# Our flag for byte processing
-	PUSH_-1
-	POP_R15                     # r15 = -1
+	PUSH !-1
+	POP_RBX                     # rbx = -1
 
 	# temp storage for the sum
-	XOR_R14D_R14D               # r14 = 0
+	XOR_EBP_EBP                 # rbp = 0
 
 :loop
 	# Read a byte
@@ -94,27 +91,26 @@ DEFINE XOR_R15D_R15D 4531FF
 	CALLI32 %hex
 
 	# deal with -1 values
-	TEST_RAX_RAX
+	TEST_EAX_EAX
 	JL8 !loop
 
 	# deal with toggle
-	TEST_R15_R15                # jump if r15 >= 0
+	TEST_EBX_EBX                # jump if rbx >= 0
 	JGE8 !print
 
 	# process first byte of pair
-	MOVE_R14_RAX
-	XOR_R15D_R15D               # r15 = 0
+	COPY_EBP_EAX
+	XOR_EBX_EBX                 # rbx = 0
 	JMP8 !loop
 
 # process second byte of pair
 :print
 	# update the sum and store in output
-	SHL_R14_Immediate8 !4
-	ADD_RAX_R14
+	SHL_EBP_Immediate8 !4
+	ADD_EAX_EBP
 
 	# flip the toggle
-	PUSH_-1
-	POP_R15                     # r15 = -1
+	DEC_EBX                     # rbx = -1
 
 	CALLI32 %write_byte
 
@@ -122,35 +118,35 @@ DEFINE XOR_R15D_R15D 4531FF
 
 :hex
 	# Purge Comment Lines (#)
-	CMP_RAX_Immediate8 !35
+	CMPI8_AL !35
 	JE8 !purge_comment
 
 	# Purge Comment Lines (;)
-	CMP_RAX_Immediate8 !59
+	CMPI8_AL !59
 	JE8 !purge_comment
 
 	# deal all ascii less than '0'
-	CMP_RAX_Immediate8 !48
+	CMPI8_AL !48
 	JL8 !ascii_other
 
 	# deal with 0-9
-	CMP_RAX_Immediate8 !58
+	CMPI8_AL !58
 	JL8 !ascii_num
 
 	# deal with all ascii less than 'A'
-	CMP_RAX_Immediate8 !65
+	CMPI8_AL !65
 	JL8 !ascii_other
 
 	# deal with 'A'-'F'
-	CMP_RAX_Immediate8 !71
+	CMPI8_AL !71
 	JL8 !ascii_high
 
 	# deal with all ascii less than 'a'
-	CMP_RAX_Immediate8 !97
+	CMPI8_AL !97
 	JL8 !ascii_other
 
 	#deal with 'a'-'f'
-	CMP_RAX_Immediate8 !103
+	CMPI8_AL !103
 	JL8 !ascii_low
 
 	# The rest that remains needs to be ignored
@@ -161,67 +157,63 @@ DEFINE XOR_R15D_R15D 4531FF
 	CALLI32 %read_byte
 
 	# Loop if not LF
-	CMP_RAX_Immediate8 !10
+	CMPI8_AL !10
 	JNE8 !purge_comment
 
 	# Otherwise return -1
-	PUSH_-1
-	POP_RAX                     # rax = -1
+
+:ascii_other
+	PUSH !-1
+	POP_RAX                     # return = -1
 	RET
 
 :ascii_num
-	SUB_RAX_Immediate8 !48
+	SUBI8_AL !48
 	RET
 
 :ascii_low
-	SUB_RAX_Immediate8 !87
-	RET
+	SUBI8_AL !32
 
 :ascii_high
-	SUB_RAX_Immediate8 !55
+	SUBI8_AL !55
 	RET
-
-:ascii_other
-	PUSH_-1
-	POP_RAX                     # rax = -1
-	RET
-
-:Done
-	# program completed Successfully
-	XOR_EDI_EDI                 # All is well, rdi = 0
-	PUSH_60                     # sycall number for exit is 60
-	POP_RAX                     # put the exit syscall number in rax
-	SYSCALL                     # Call it a good day
 
 # Writes byte stored in al
 :write_byte
 	# Print our Hex
-	PUSH_1                      # prepare to set rdx to 1
+	PUSH !1                     # prepare to set rdx to 1
 	POP_RDX                     # set the size of chars we want
 	PUSH_RAX                    # Move output to stack
 	COPY_RSP_to_RSI             # What we are writing
 	COPY_R10_to_RDI             # Where are we writing to
-	PUSH_1                      # prepare syscall number for write
+	PUSH !1                     # prepare syscall number for write
 	POP_RAX                     # get the syscall number for write
 	SYSCALL                     # call the Kernel
-	POP_RBX                     # deallocate stack
+	POP_RDI                     # deallocate stack
 	RET
 
 :read_byte
 	# Attempt to read 1 byte from STDIN
-	PUSH_1                      # prepare to set rdx to 1
+	PUSH !1                     # prepare to set rdx to 1
 	POP_RDX                     # set the size of chars we want
-	PUSH_RBX                    # allocate stack
+	PUSH_RDI                    # allocate stack
 	COPY_RSP_to_RSI             # Where to put it
 	COPY_R9_to_RDI              # Where are we reading from
 	XOR_EAX_EAX                 # the syscall number for read, rax = 0
 	SYSCALL                     # call the Kernel
 
-	TEST_RAX_RAX                # check what we got
+	TEST_EAX_EAX                # check what we got
 	JE8 !Done                   # Got EOF call it done
 
 	# load byte
 	POP_RAX                     # load char
 	RET
+
+:Done
+	# program completed Successfully
+	XOR_EDI_EDI                 # All is well, rdi = 0
+	PUSH !60                    # sycall number for exit is 60
+	POP_RAX                     # put the exit syscall number in rax
+	SYSCALL                     # Call it a good day
 
 :ELF_end

--- a/NASM/hex0_AMD64.S
+++ b/NASM/hex0_AMD64.S
@@ -1,4 +1,5 @@
 ;; Copyright (C) 2017 Jeremiah Orians
+;; Copyright (C) 2022 Andrius Štikonas <andrius@stikonas.eu>
 ;; This file is part of stage0.
 ;;
 ;; stage0 is free software: you can redistribute it and/or modify
@@ -31,8 +32,8 @@ _start:
 	mov r9, rax                 ; Preserve the file pointer we were given
 
 	pop rdi                     ; Get the actual output name
-	mov rsi, 577                ; Prepare file as O_WRONLY|O_CREAT|O_TRUNC
-	mov rdx, 448                ; Prepare file as RWX for owner only (700 in octal)
+	mov si, 577                 ; Prepare file as O_WRONLY|O_CREAT|O_TRUNC
+	mov dx, 448                 ; Prepare file as RWX for owner only (700 in octal)
 	push 2                      ; prepare syscall number
 	pop rax                     ; the syscall number for open()
 	syscall                     ; Now open that damn file
@@ -40,10 +41,10 @@ _start:
 
 	; Our flag for byte processing
 	push -1
-	pop r15                     ; r15 = -1
+	pop rbx                     ; rbx = -1
 
 	; tmp storage for the sum
-	xor r14d, r14d              ; r14 = 0
+	xor rbp, rbp                ; rbp = 0
 
 loop:
 	; Read a byte
@@ -53,27 +54,26 @@ loop:
 	call hex
 
 	; Deal with -1 values
-	test rax, rax
+	test eax, eax
 	jl loop
 
 	; deal with toggle
-	test r15, r15               ; jump if r15 >= 0
+	test ebx, ebx               ; jump if ebx >= 0
 	jge print
 
 	; process first byte of pair
-	mov r14, rax
-	xor r15d, r15d              ; r15 = 0
+	mov ebp, eax
+	xor ebx, ebx                ; rbx = 0
 	jmp loop
 
 ; process second byte of pair
 print:
 	; update the sum and store in output
-	shl r14, 4
-	add rax, r14
+	shl ebp, 4
+	add eax, ebp
 
 	; flip the toggle
-	push -1
-	pop r15                     ; r15 = -1
+	dec ebx                     ; rbx = -1
 
 	call write_byte
 
@@ -81,35 +81,35 @@ print:
 
 hex:
 	; Purge Comment Lines (#)
-	cmp rax, 35
+	cmp al, 35
 	je purge_comment
 
 	; Purge Comment Lines (;)
-	cmp rax, 59
+	cmp al, 59
 	je purge_comment
 
 	; deal all ascii less than 0
-	cmp rax, 48
+	cmp al, 48
 	jl ascii_other
 
 	; deal with 0-9
-	cmp rax, 58
+	cmp al, 58
 	jl ascii_num
 
 	; deal with all ascii less than A
-	cmp rax, 65
+	cmp al, 65
 	jl ascii_other
 
 	; deal with A-F
-	cmp rax, 71
+	cmp al, 71
 	jl ascii_high
 
 	;deal with all ascii less than a
-	cmp rax, 97
+	cmp al, 97
 	jl ascii_other
 
 	;deal with a-f
-	cmp rax, 103
+	cmp al, 103
 	jl ascii_low
 
 	; The rest that remains needs to be ignored
@@ -120,37 +120,26 @@ purge_comment:
 	call Read_byte
 
 	; Loop if not LF
-	cmp rax, 10
+	cmp al, 10
 	jne purge_comment
 
 	; Otherwise return -1
-	push -1
-	pop rax                     ; rax = -1
-	ret
-
-ascii_num:
-	sub rax, 48
-	ret
-
-ascii_low:
-	sub rax, 87
-	ret
-
-ascii_high:
-	sub rax, 55
-	ret
 
 ascii_other:
 	push -1
-	pop rax                     ; rax = -1
+	pop rax                     ; return -1
 	ret
 
-Done:
-	; program completed Successfully
-	xor edi, edi                ; All is well, rdi = 0
-	push 60                     ; sycall number for exit is 60
-	pop rax                     ; put the exit syscall number in eax
-	syscall                     ; Call it a good day
+ascii_num:
+	sub al, 48
+	ret
+
+ascii_low:
+	sub al, 32
+
+ascii_high:
+	sub al, 55
+	ret
 
 ; Writes byte stored in al
 write_byte:
@@ -163,26 +152,31 @@ write_byte:
 	push 1                      ; prepare syscall number for write
 	pop rax                     ; get the syscall number for write
 	syscall                     ; call the Kernel
-	pop rbx                     ; deallocate stack
+	pop rdi                     ; deallocate stack
 	ret
 
 Read_byte:
 	; Attempt to read 1 byte from STDIN
 	push 1                      ; prepare to set rdx to 1
 	pop rdx                     ; set the size of chars we want
-	push rbx                    ; allocate stack
+	push rdi                    ; allocate stack
 	mov rsi, rsp                ; Where to put it
 	mov rdi, r9                 ; Where are we reading from
 	xor eax, eax                ; the syscall number for read, rax = 0
 	syscall                     ; call the Kernel
 
-	test rax, rax               ; check what we got
+	test eax, eax               ; check what we got
 	je Done                     ; Got EOF call it done
 
 	; load byte
 	pop rax                     ; load char
 	ret
 
+Done:
+	; program completed Successfully
+	xor edi, edi                ; All is well, rdi = 0
+	push 60                     ; sycall number for exit is 60
+	pop rax                     ; put the exit syscall number in eax
+	syscall                     ; Call it a good day
 
-section .data
 ELF_end:

--- a/hex0_AMD64.hex0
+++ b/hex0_AMD64.hex0
@@ -60,8 +60,8 @@
 00 00 60 00 00 00 00 00 ## p_vaddr
 00 00 60 00 00 00 00 00 ## p_physaddr
 
-4E 01 00 00 00 00 00 00 ## p_filesz
-4E 01 00 00 00 00 00 00 ## p_memsz
+24 01 00 00 00 00 00 00 ## p_filesz
+24 01 00 00 00 00 00 00 ## p_memsz
 
 01 00 00 00 00 00 00 00 ## Required alignment
 
@@ -70,167 +70,162 @@
 # Where the ELF Header is going to hit
 # Simply jump to _start
 # Our main function
-#:_start
+#:_start (0x600078)
 	58                  ; POP_RAX         # Get the number of arguments
 	5F                  ; POP_RDI         # Get the program name
 	5F                  ; POP_RDI         # Get the actual input name
 	31F6                ; XOR_ESI_ESI     # prepare read_only, rsi = 0
-	6A02                ; PUSH_2          # prepare syscall number
+	6A02                ; PUSH !2         # prepare syscall number
 	58                  ; POP_RAX         # the syscall number for open()
 	0F05                ; SYSCALL         # Now open that damn file
 	4989C1              ; COPY_RAX_to_R9  # Preserve the file pointer we were given
 
 	5F                  ; POP_RDI         # Get the actual output name
-	BE 41020000         ; LOADI32_ESI %577 # Prepare file as O_WRONLY|O_CREAT|O_TRUNC
-	BA C0010000         ; LOADI32_EDX %448 # Prepare file as RWX for owner only (700 in octal)
-	6A02                ; PUSH_2          # prepare syscall number
+	66BE 4102           ; LOADI16_SI @577 # Prepare file as O_WRONLY|O_CREAT|O_TRUNC
+	66BA C001           ; LOADI16_DX @448 # Prepare file as RWX for owner only (700 in octal)
+	6A02                ; PUSH !2         # prepare syscall number
 	58                  ; POP_RAX         # the syscall number for open()
 	0F05                ; SYSCALL         # Now open that damn file
 	4989C2              ; COPY_RAX_to_R10 # Preserve the file pointer we were given
 
 	# Our flag for byte processing
-	6AFF                ; PUSH_-1
-	415F                ; POP_R15         # r15 = -1
+	6AFF                ; PUSH !-1
+	5B                  ; POP_RBX         # rbx = -1
 
 	# temp storage for the sum
-	4531F6              ; XOR_R14D_R14D   # r14 = 0
+	31ED                ; XOR_EBP_EBP     # rbp = 0
 
-#:loop
+#:loop (0x60009B)
 	# Read a byte
-	E8 95000000         ; CALLI32 %read_byte
+	E8 69000000         ; CALLI32 %read_byte
 
 	# process byte
-	E8 24000000         ; CALLI32 %hex
+	E8 1C000000         ; CALLI32 %hex
 
 	# deal with -1 values
-	4885C0              ; TEST_RAX_RAX
-	7C F1               ; JL8 !loop
+	85C0                ; TEST_EAX_EAX
+	7C F2               ; JL8 !loop
 
 	# deal with toggle
-	4D85FF              ; TEST_R15_R15    # jump if r15 >= 0
-	7D 08               ; JGE8 !print
+	85DB                ; TEST_EBX_EBX    # jump if rbx >= 0
+	7D 06               ; JGE8 !print
 
 	# process first byte of pair
-	4989C6              ; MOVE_R14_RAX
-	4531FF              ; XOR_R15D_R15D   # r15 = 0
-	EB E4               ; JMP8 !loop
+	89C5                ; COPY_EBP_EAX
+	31DB                ; XOR_EBX_EBX     # rbx = 0
+	EB E8               ; JMP8 !loop
 
 # process second byte of pair
-#:print
+#:print (0x6000B3)
 	# update the sum and store in output
-	49C1E6 04           ; SHL_R14_Immediate8 !4
-	4C01F0              ; ADD_RAX_R14
+	C1E5 04             ; SHL_EBP_Immediate8 !4
+	01E8                ; ADD_EAX_EBP
 
 	# flip the toggle
-	6AFF                ; PUSH_-1
-	415F                ; POP_R15         # r15 = -1
+	FFCB                ; DEC_EBX         # rbx = -1
 
-	E8 5D000000         ; CALLI32 %write_byte
+	E8 39000000         ; CALLI32 %write_byte
 
-	EB D2               ; JMP8 !loop
+	EB DA               ; JMP8 !loop
 
-#:hex
+#:hex (0x6000C1)
 	# Purge Comment Lines (#)
-	4883F8 23           ; CMP_RAX_Immediate8 !35
-	74 2C               ; JE8 !purge_comment
+	3C 23               ; CMPI8_AL !35
+	74 1E               ; JE8 !purge_comment
 
 	# Purge Comment Lines (;)
-	4883F8 3B           ; CMP_RAX_Immediate8 !59
-	74 26               ; JE8 !purge_comment
+	3C 3B               ; CMPI8_AL !59
+	74 1A               ; JE8 !purge_comment
 
 	# deal all ascii less than '0'
-	4883F8 30           ; CMP_RAX_Immediate8 !48
-	7C 3E               ; JL8 !ascii_other
+	3C 30               ; CMPI8_AL !48
+	7C 1F               ; JL8 !ascii_other
 
 	# deal with 0-9
-	4883F8 3A           ; CMP_RAX_Immediate8 !58
-	7C 29               ; JL8 !ascii_num
+	3C 3A               ; CMPI8_AL !58
+	7C 1F               ; JL8 !ascii_num
 
 	# deal with all ascii less than 'A'
-	4883F8 41           ; CMP_RAX_Immediate8 !65
-	7C 32               ; JL8 !ascii_other
+	3C 41               ; CMPI8_AL !65
+	7C 17               ; JL8 !ascii_other
 
 	# deal with 'A'-'F'
-	4883F8 47           ; CMP_RAX_Immediate8 !71
-	7C 27               ; JL8 !ascii_high
+	3C 47               ; CMPI8_AL !71
+	7C 1C               ; JL8 !ascii_high
 
 	# deal with all ascii less than 'a'
-	4883F8 61           ; CMP_RAX_Immediate8 !97
-	7C 26               ; JL8 !ascii_other
+	3C 61               ; CMPI8_AL !97
+	7C 0F               ; JL8 !ascii_other
 
 	#deal with 'a'-'f'
-	4883F8 67           ; CMP_RAX_Immediate8 !103
-	7C 16               ; JL8 !ascii_low
+	3C 67               ; CMPI8_AL !103
+	7C 12               ; JL8 !ascii_low
 
 	# The rest that remains needs to be ignored
-	EB 1E               ; JMP8 !ascii_other
+	EB 09               ; JMP8 !ascii_other
 
-#:purge_comment
+#:purge_comment (0x6000E3)
 	# Read a byte
-	E8 35000000         ; CALLI32 %read_byte
+	E8 21000000         ; CALLI32 %read_byte
 
 	# Loop if not LF
-	4883F8 0A           ; CMP_RAX_Immediate8 !10
-	75 F5               ; JNE8 !purge_comment
+	3C 0A               ; CMPI8_AL !10
+	75 F7               ; JNE8 !purge_comment
 
 	# Otherwise return -1
+
+#:ascii_other (0x6000EC)
 	6AFF                ; PUSH_-1
-	58                  ; POP_RAX         # rax = -1
+	58                  ; POP_RAX         # return = -1
 	C3                  ; RET
 
-#:ascii_num
-	4883E8 30           ; SUB_RAX_Immediate8 !48
+#:ascii_num (0x6000F0)
+	2C 30               ; SUBI8_AL !48
 	C3                  ; RET
 
-#:ascii_low
-	4883E8 57           ; SUB_RAX_Immediate8 !87
-	C3                  ; RET
+#:ascii_low (0x6000F3)
+	2C 20               ; SUBI8_AL !32
 
-#:ascii_high
-	4883E8 37           ; SUB_RAX_Immediate8 !55
+#:ascii_high (0x6000F5)
+	2C 37               ; SUBI8_AL !55
 	C3                  ; RET
-
-#:ascii_other
-	6AFF                ; PUSH_-1
-	58                  ; POP_RAX         # rax = -1
-	C3                  ; RET
-
-#:Done
-	# program completed Successfully
-	31FF                ; XOR_EDI_EDI     # All is well, rdi = 0
-	6A3C                ; PUSH_60         # sycall number for exit is 60
-	58                  ; POP_RAX         # put the exit syscall number in rax
-	0F05                ; SYSCALL         # Call it a good day
 
 # Writes byte stored in al
-#:write_byte
+#:write_byte (0x6000F8)
 	# Print our Hex
-	6A01                ; PUSH_1          # prepare to set rdx to 1
+	6A01                ; PUSH !1         # prepare to set rdx to 1
 	5A                  ; POP_RDX         # set the size of chars we want
 	50                  ; PUSH_RAX        # Move output to stack
 	4889E6              ; COPY_RSP_to_RSI # What we are writing
 	4C89D7              ; COPY_R10_to_RDI # Where are we writing to
-	6A01                ; PUSH_1          # prepare syscall number for write
+	6A01                ; PUSH !1         # prepare syscall number for write
 	58                  ; POP_RAX         # get the syscall number for write
 	0F05                ; SYSCALL         # call the Kernel
-	5B                  ; POP_RBX         # deallocate stack
+	5F                  ; POP_RDI         # deallocate stack
 	C3                  ; RET
 
-#:read_byte
+#:read_byte (0x600109)
 	# Attempt to read 1 byte from STDIN
-	6A01                ; PUSH_1          # prepare to set rdx to 1
+	6A01                ; PUSH !1         # prepare to set rdx to 1
 	5A                  ; POP_RDX         # set the size of chars we want
-	53                  ; PUSH_RBX        # allocate stack
+	57                  ; PUSH_RDI        # allocate stack
 	4889E6              ; COPY_RSP_to_RSI # Where to put it
 	4C89CF              ; COPY_R9_to_RDI  # Where are we reading from
 	31C0                ; XOR_EAX_EAX     # the syscall number for read
 	0F05                ; SYSCALL         # call the Kernel
 
-	4885C0              ; TEST_RAX_RAX    # check what we got
-	74 D5               ; JE8 !Done       # Got EOF call it done
+	85C0                ; TEST_EAX_EAX    # check what we got
+	74 02               ; JE8 !Done       # Got EOF call it done
 
 	# load byte
 	58                  ; POP_RAX         # load char
 	C3                  ; RET
+
+#:Done (0x60011D)
+	# program completed Successfully
+	31FF                ; XOR_EDI_EDI     # All is well, rdi = 0
+	6A3C                ; PUSH !60        # sycall number for exit is 60
+	58                  ; POP_RAX         # put the exit syscall number in rax
+	0F05                ; SYSCALL         # Call it a good day
 
 #:ELF_end


### PR DESCRIPTION
In addition to that use smaller x86_64 registers where possible,
e.g. ebp, ebx instead of r14, r15.