### PR TITLE
Add support for anonymous enums for constant values

### DIFF
--- a/GAS/cc_amd64.S
+++ b/GAS/cc_amd64.S
@@ -648,6 +648,10 @@ fputc:
     pop rax                     # Restore stack
     ret
 
+enum_error_open_curly: .asciz "ERROR in enum\nExpected {\n"
+enum_error_equal: .asciz "ERROR in enum\nExpected =\n"
+enum_error_close_curly: .asciz "ERROR in enum\nExpected }\n"
+enum_error_semi_colon: .asciz "ERROR in enum\nExpected ;\n"
 
 # program function
 # receives nothing, returns nothing
@@ -658,6 +662,80 @@ program:
     push rcx                    # Protect RCX
 
 new_type:
+    mov rax, [rip+global_token] # Using global_token
+    cmp rax, 0                  # Check if NULL
+    je program_done             # Be done if null
+
+    mov rbx, [rax+16]           # GLOBAL_TOKEN->S
+    lea rax, [rip+enum]         # "enum"
+    call match                  # IF GLOBAL_TOKEN->S == "enum"
+    cmp rax, 0                  # If true
+    jne constant_value          # Looks like not an enum
+
+    # Deal with minimal anonymous enums
+    mov rax, [rip+global_token]           # Using global_token
+    mov rax, [rax]                        # global_token->next
+    mov [rip+global_token], rax           # global_token = global_token->next
+
+    lea rax, [rip+enum_error_open_curly]  # Using "ERROR in enum\nExpected {\n"
+    lea rbx, [rip+open_curly_brace]       # Using "{"
+    call require_match                    # Require match and skip
+
+enumerator:
+    mov rax, [rip+global_token]           # Using global token
+    mov rax, [rax+16]                     # global_token->s
+    mov rbx, 0                            # NULL
+    mov rcx, [rip+global_constant_list]   # global_constant_list
+    call sym_declare                      # Declare the constant
+    mov [rip+global_constant_list], rax   # global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+
+    mov rax, [rip+global_token]           # Using global_token
+    mov rax, [rax]                        # global_token->next
+    mov [rip+global_token], rax           # global_token = global_token->next
+
+    lea rax, [rip+enum_error_equal]       # Using "ERROR in enum\nExpected =\n"
+    lea rbx, [rip+equal]                  # Using "="
+    call require_match                    # Require match and skip
+
+    mov rbx, [rip+global_token]           # Using global_token
+    mov rax, [rip+global_constant_list]   # Use global_constant_list
+    mov [rax+32], rbx                     # global_constant_list->arguments = global_token
+
+    mov rax, [rip+global_token]           # Using global_token
+    mov rax, [rax]                        # global_token->next
+    mov [rip+global_token], rax           # global_token = global_token->next
+
+    mov rax, [rip+global_token]           # Use global_token
+    mov rbx, [rax+16]                     # global_token->s
+    lea rax, [rip+comma]                  # ","
+    call match                            # IF global_token->s == ","
+    cmp rax, 0                            # If true
+    jne enum_end                          # No comma means no more enumerators
+
+    # Skip comma
+    mov rax, [rip+global_token]           # Using global_token
+    mov rax, [rax]                        # global_token->next
+    mov [rip+global_token], rax           # global_token = global_token->next
+
+    # Check if there are more enumerators or if it was a trailing comma
+    mov rbx, [rax+16]                     # global_token->s
+    lea rax, [rip+close_curly_brace]      # "}"
+    call match                            # IF global_token->s == "}"
+    cmp rax, 0                            # If true
+    jne enumerator                        # More enumerators
+
+enum_end:
+    lea rax, [rip+enum_error_close_curly] # Using "ERROR in enum\nExpected }\n"
+    lea rbx, [rip+close_curly_brace]      # Using "}"
+    call require_match                    # Require match and skip
+
+    lea rax, [rip+enum_error_semi_colon]  # Using "ERROR in enum\nExpected ;\n"
+    lea rbx, [rip+semicolon]              # Using ";"
+    call require_match                    # Require match and skip
+
+    jmp new_type                          # go around again
+
+constant_value:
     mov rax, [rip+global_token] # Using global_token
     cmp rax, 0                  # Check if NULL
     je program_done             # Be done if null
@@ -4501,6 +4579,7 @@ debug_list_string_null: .asciz ">::<NULL>::<"
 # Keywords
 union: .asciz "union"
 struct: .asciz "struct"
+enum: .asciz "enum"
 constant: .asciz "CONSTANT"
 main_string: .asciz "main"
 argc_string: .asciz "argc"

--- a/NASM/cc_x86.S
+++ b/NASM/cc_x86.S
@@ -607,6 +607,10 @@ fputc:
 	pop rax                     ; Restore stack
 	ret
 
+enum_error_open_curly: db "ERROR in enum\nExpected {\n", 0
+enum_error_equal: db "ERROR in enum\nExpected =\n", 0
+enum_error_close_curly: db "ERROR in enum\nExpected }\n", 0
+enum_error_semi_colon: db "ERROR in enum\nExpected ;\n", 0
 
 ;; program function
 ;; receives nothing, returns nothing
@@ -617,6 +621,80 @@ program:
 	push rcx                    ; Protect RCX
 
 new_type:
+	mov rax, [global_token]     ; Using global_token
+	cmp rax, 0                  ; Check if NULL
+	je program_done             ; Be done if null
+
+	mov rbx, [rax+16]           ; GLOBAL_TOKEN->S
+	lea rax, [enum]             ; "enum"
+	call match                  ; IF GLOBAL_TOKEN->S == "enum"
+	cmp rax, 0                  ; If true
+	jne constant_value          ; Looks like not an enum
+
+	; Deal with minimal anonymous enums
+	mov rax, [global_token]           ; Using global_token
+	mov rax, [rax]                    ; global_token->next
+	mov [global_token], rax           ; global_token = global_token->next
+
+	lea rax, [enum_error_open_curly]  ; Using "ERROR in enum\nExpected {\n"
+	lea rbx, [open_curly_brace]       ; Using "{"
+	call require_match                ; Require match and skip
+
+enumerator:
+	mov rax, [global_token]           ; Using global token
+	mov rax, [rax+16]                 ; global_token->s
+	mov rbx, 0                        ; NULL
+	mov rcx, [global_constant_list]   ; global_constant_list
+	call sym_declare                  ; Declare the constant
+	mov [global_constant_list], rax   ; global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+
+	mov rax, [global_token]           ; Using global_token
+	mov rax, [rax]                    ; global_token->next
+	mov [global_token], rax           ; global_token = global_token->next
+
+	lea rax, [enum_error_equal]       ; Using "ERROR in enum\nExpected =\n"
+	lea rbx, [equal]                  ; Using "="
+	call require_match                ; Require match and skip
+
+	mov rbx, [global_token]           ; Using global_token
+	mov rax, [global_constant_list]   ; Use global_constant_list
+	mov [rax+32], rbx                 ; global_constant_list->arguments = global_token
+
+	mov rax, [global_token]           ; Using global_token
+	mov rax, [rax]                    ; global_token->next
+	mov [global_token], rax           ; global_token = global_token->next
+
+	mov rax, [global_token]           ; Use global_token
+	mov rbx, [rax+16]                 ; global_token->s
+	lea rax, [comma]                  ; ","
+	call match                        ; IF global_token->s == ","
+	cmp rax, 0                        ; If true
+	jne enum_end                      ; No comma means no more enumerators
+
+	; Skip comma
+	mov rax, [global_token]           ; Using global_token
+	mov rax, [rax]                    ; global_token->next
+	mov [global_token], rax           ; global_token = global_token->next
+
+	; Check if there are more enumerators or if it was a trailing comma
+	mov rbx, [rax+16]                 ; global_token->s
+	lea rax, [close_curly_brace]      ; "}"
+	call match                        ; IF global_token->s == "}"
+	cmp rax, 0                        ; If true
+	jne enumerator                    ; More enumerators
+
+enum_end:
+	lea rax, [enum_error_close_curly] ; Using "ERROR in enum\nExpected }\n"
+	lea rbx, [close_curly_brace]      ; Using "}"
+	call require_match                ; Require match and skip
+
+	lea rax, [enum_error_semi_colon]  ; Using "ERROR in enum\nExpected ;\n"
+	lea rbx, [semicolon]              ; Using ";"
+	call require_match                ; Require match and skip
+
+	jmp new_type                      ; go around again
+
+constant_value:
 	mov rax, [global_token]     ; Using global_token
 	cmp rax, 0                  ; Check if NULL
 	je program_done             ; Be done if null
@@ -4375,6 +4453,7 @@ Exit_Failure:
 ;; Keywords
 union: db "union", 0
 struct: db "struct", 0
+enum: db "enum", 0
 constant: db "CONSTANT", 0
 main_string: db "main", 0
 argc_string: db "argc", 0

--- a/cc_amd64.M1
+++ b/cc_amd64.M1
@@ -841,6 +841,14 @@ DEFINE NULL 0000000000000000
     pop_rax                     # Restore stack
     ret
 
+:enum_error_open_curly
+"ERROR in enum\nExpected {\n"
+:enum_error_equal
+"ERROR in enum\nExpected =\n"
+:enum_error_close_curly
+"ERROR in enum\nExpected }\n"
+:enum_error_semi_colon
+"ERROR in enum\nExpected ;\n"
 
 # program function
 # receives nothing, returns nothing
@@ -851,6 +859,80 @@ DEFINE NULL 0000000000000000
     push_rcx                                  # Protect RCX
 
 :new_type
+    mov_rax,[rip+DWORD] %global_token         # Using global_token
+    cmp_rax, %0                               # Check if NULL
+    je %program_done                          # Be done if null
+
+    mov_rbx,[rax+BYTE] !16                      # GLOBAL_TOKEN->S
+    lea_rax,[rip+DWORD] %enum                   # "enum"
+    call %match                                 # IF GLOBAL_TOKEN->S == "enum"
+    cmp_rax, %0                                 # If true
+    jne %constant_value                         # Looks like not an enum
+
+    # Deal with minimal anonymous enums
+    mov_rax,[rip+DWORD] %global_token           # Using global_token
+    mov_rax,[rax]                               # global_token->next
+    mov_[rip+DWORD],rax %global_token           # global_token = global_token->next
+
+    lea_rax,[rip+DWORD] %enum_error_open_curly  # Using "ERROR in enum\nExpected {\n"
+    lea_rbx,[rip+DWORD] %open_curly_brace       # Using "{"
+    call %require_match                         # Require match and skip
+
+:enumerator
+    mov_rax,[rip+DWORD] %global_token           # Using global token
+    mov_rax,[rax+BYTE] !16                      # global_token->S
+    mov_rbx, %0                                 # NULL
+    mov_rcx,[rip+DWORD] %global_constant_list   # global_constant_list
+    call %sym_declare                           # Declare the constant
+    mov_[rip+DWORD],rax %global_constant_list   # global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+
+    mov_rax,[rip+DWORD] %global_token           # Using global_token
+    mov_rax,[rax]                               # global_token->next
+    mov_[rip+DWORD],rax %global_token           # global_token = global_token->next
+
+    lea_rax,[rip+DWORD] %enum_error_equal       # Using "ERROR in enum\nExpected =\n"
+    lea_rbx,[rip+DWORD] %equal                  # Using "="
+    call %require_match                         # Require match and skip
+
+    mov_rbx,[rip+DWORD] %global_token           # Using global_token
+    mov_rax,[rip+DWORD] %global_constant_list   # Use global_constant_list
+    mov_[rax+BYTE],rbx !32                      # global_constant_list->arguments = global_token->next
+
+    mov_rax,[rip+DWORD] %global_token           # Using global_token
+    mov_rax,[rax]                               # global_token->next
+    mov_[rip+DWORD],rax %global_token           # global_token = global_token->next
+
+    mov_rbx,[rip+DWORD] %global_token           # Use global_token
+    mov_rbx,[rax+BYTE] !16                      # global_token->s
+    lea_rax,[rip+DWORD] %comma                  # ","
+    call %match                                 # IF global_token->s == ","
+    cmp_rax, %0                                 # If true
+    jne %enum_end                               # No comma means no more enumerators
+
+    # Skip comma
+    mov_rax,[rip+DWORD] %global_token           # Using global_token
+    mov_rax,[rax]                               # global_token->next
+    mov_[rip+DWORD],rax %global_token           # global_token = global_token->next
+
+    # Check if there are more enumerators or if it was a trailing comma
+    mov_rbx,[rax+BYTE] !16                      # global_token->s
+    lea_rax,[rip+DWORD] %close_curly_brace      # "}"
+    call %match                                 # IF global_token->s == "}"
+    cmp_rax, %0                                 # If true
+    jne %enumerator                             # More enumerators
+
+:enum_end
+    lea_rax,[rip+DWORD] %enum_error_close_curly # Using "ERROR in enum\nExpected }\n"
+    lea_rbx,[rip+DWORD] %close_curly_brace      # Using "}"
+    call %require_match                         # Require match and skip
+
+    lea_rax,[rip+DWORD] %enum_error_semi_colon  # Using "ERROR in enum\nExpected ;\n"
+    lea_rbx,[rip+DWORD] %semicolon              # Using ";"
+    call %require_match                         # Require match and skip
+
+    jmp %new_type                               # go around again
+
+:constant_value
     mov_rax,[rip+DWORD] %global_token         # Using global_token
     cmp_rax, %0                               # Check if NULL
     je %program_done                          # Be done if null
@@ -5166,6 +5248,9 @@ ARGUMENTS address: "
 
 :struct
 "struct"
+
+:enum
+"enum"
 
 :constant
 "CONSTANT"


### PR DESCRIPTION
@stikonas @oriansj 

Took a stab at adding anonymous enum support to replace the `// CONSTANT` syntax. 

I wasn't sure if all three files were supposed to be kept up to date, but it wasn't a big deal to convert from gas to nasm so it doesn't matter. I used `gas` to prototype and then converted to M1 afterwards.

Both trailing and non-trailing commas are allowed with this. I felt it was better than either always requiring a comma (not C89 compatible) or not allowing trailing commas since they make for better diffs.

I used the following file to test
```c
// CONSTANT TEST5 5
enum {
    TEST1 = 1,
    TEST2 = 2
};

enum {
    TEST3 = 3,
    TEST4 = 4,
};

int main() {
    return TEST1 + TEST2 + TEST3 + TEST4 + TEST5;
}
```

It outputs the following with `gas`
```
# Core program
# Defining function main
:FUNCTION_main
mov_rax, %1
push_rax        #_common_recursion
mov_rax, %2
pop_rbx # _common_recursion
add_rax,rbx
push_rax        #_common_recursion
mov_rax, %3
pop_rbx # _common_recursion
add_rax,rbx
push_rax        #_common_recursion
mov_rax, %4
pop_rbx # _common_recursion
add_rax,rbx
push_rax        #_common_recursion
mov_rax, %5
pop_rbx # _common_recursion
add_rax,rbx
ret

# Program global variables

# Program strings

:ELF_end
```

I also tried running `stage0-posix` both with no changes and with the patch below.
IMO it massively improves readability.

```patch
diff --git a/cc.h b/cc.h
index 4886fce..0d5978d 100644
--- a/cc.h
+++ b/cc.h
@@ -20,38 +20,32 @@
 #include <stdio.h>
 #include <string.h>
 
-// CONSTANT FALSE 0
-#define FALSE 0
-// CONSTANT TRUE 1
-#define TRUE 1
+enum {
+    FALSE = 0,
+    TRUE = 1,
+};
 
-// CONSTANT KNIGHT_NATIVE 1
-#define KNIGHT_NATIVE 1
-// CONSTANT KNIGHT_POSIX 2
-#define KNIGHT_POSIX 2
-// CONSTANT X86 3
-#define X86 3
-// CONSTANT AMD64 4
-#define AMD64 4
-// CONSTANT ARMV7L 5
-#define ARMV7L 5
-// CONSTANT AARCH64 6
-#define AARCH64 6
-// CONSTANT RISCV32 7
-#define RISCV32 7
-// CONSTANT RISCV64 8
-#define RISCV64 8
+enum {
+    KNIGHT_NATIVE = 1,
+    KNIGHT_POSIX = 2,
+    X86 = 3,
+    AMD64 = 4,
+    ARMV7L = 5,
+    AARCH64 = 6,
+    RISCV32 = 7,
+    RISCV64 = 8,
+};
 
-/* Stack grows to higher memory addresses */
-// CONSTANT STACK_DIRECTION_PLUS 0
-#define STACK_DIRECTION_PLUS 0
+enum {
+    /* Stack grows to higher memory addresses */
+    STACK_DIRECTION_PLUS = 0,
+    /* Stack grows to lower memory addresses */
+    STACK_DIRECTION_MINUS = 1,
+};
 
-/* Stack grows to lower memory addresses */
-// CONSTANT STACK_DIRECTION_MINUS 1
-#define STACK_DIRECTION_MINUS 1
-
-// CONSTANT NO_STRUCT_DEFINITION 0
-#define NO_STRUCT_DEFINITION 0
+enum {
+    NO_STRUCT_DEFINITION = 0,
+};
 
 int copy_string(char* target, char* source, int max);
 int string_length(char* a);

```