### PR TITLE
Fix stale token buffer suffixes

### DIFF
--- a/GAS/cc_amd64.S
+++ b/GAS/cc_amd64.S
@@ -511,6 +511,8 @@ consume_byte:
     mov rbx, [rip+string_index] # S[0]
     mov [rbx], al               # S[0] = C
     add rbx, 1                  # S = S + 1
+    mov rax, 0                  # NULL terminate S
+    mov [rbx], al               # S[0] = NULL
     mov [rip+string_index], rbx # Update S
     call fgetc
     pop rbx                     # Restore RBX

--- a/GAS/cc_x86.S
+++ b/GAS/cc_x86.S
@@ -500,6 +500,8 @@ consume_byte:
     mov rbx, [rip+string_index] # S[0]
     mov [rbx], al               # S[0] = C
     add rbx, 1                  # S = S + 1
+    mov rax, 0                  # NULL terminate S
+    mov [rbx], al               # S[0] = NULL
     mov [rip+string_index], rbx # Update S
     call fgetc
     pop rbx                     # Restore RBX

--- a/cc_amd64.M1
+++ b/cc_amd64.M1
@@ -702,6 +702,8 @@ DEFINE NULL 0000000000000000
     mov_rbx,[rip+DWORD] %string_index # S[0]
     mov_[rbx],al                 # S[0] = C
     add_rbx, %1                  # S = S + 1
+    mov_rax, %0                  # NULL terminate S
+    mov_[rbx],al                 # S[0] = NULL
     mov_[rip+DWORD],rbx %string_index # Update S
     call %fgetc
     pop_rbx                      # Restore RBX


### PR DESCRIPTION
NUL-terminate the token buffer after each consumed byte so shorter tokens cannot retain stale suffix data.