### PR TITLE
Exit catm with an error when an input file cannot be opened

### DIFF
--- a/GAS/catm_amd64.S
+++ b/GAS/catm_amd64.S
@@ -44,6 +44,8 @@ core:
     mov rdx, 0                  # prevent any interactions
     mov rax, 2                  # the syscall number for open()
     syscall                     # Now open that damn file
+    test rax, rax               # Check if the open failed
+    js fail                     # A negative result means error
     mov r13, rax                # Protect INPUT
 keep:
     mov rdx, 0x100000           # set the size of chars we want
@@ -51,6 +53,8 @@ keep:
     mov rdi, r13                # Where are we reading from
     mov rax, 0                  # the syscall number for read
     syscall                     # call the Kernel
+    test rax, rax               # Check if the read failed
+    js fail                     # A negative result means error
     push rax                    # Protect the number of bytes read
 
     mov rdx, rax                # Number of bytes to write
@@ -63,6 +67,12 @@ keep:
     cmp rax, 0x100000           # Check if buffer was fully used
     je keep                     # Keep looping if was full
     jmp core                    # Otherwise move to next file
+
+fail:
+    # an input file could not be read
+    mov rdi, 1                  # All is not well
+    mov rax, 0x3c               # put the exit syscall number in eax
+    syscall                     # Call it a bad day
 
 done:
     # program completed Successfully

--- a/catm_AMD64.hex2
+++ b/catm_AMD64.hex2
@@ -79,6 +79,8 @@
 	48C7C2 00000000             ; mov_rdx, %0                 # prevent any interactions
 	48C7C0 02000000             ; mov_rax, %2                 # the syscall number for open()
 	0F05                        ; syscall                     # Now open that damn file
+	4885C0                      ; test_rax,rax                # Check if the open failed
+	0F88 %fail                  ; js %fail                    # A negative result means error
 	4989C5                      ; mov_r13,rax                 # Protect INPUT
 :keep
 	48C7C2 00001000             ; mov_rdx, %0x100000          # set the size of chars we want
@@ -86,6 +88,8 @@
 	4C89EF                      ; mov_rdi,r13                 # Where are we reading from
 	48C7C0 00000000             ; mov_rax, %0                 # the syscall number for read
 	0F05                        ; syscall                     # call the Kernel
+	4885C0                      ; test_rax,rax                # Check if the read failed
+	0F88 %fail                  ; js %fail                    # A negative result means error
 	50                          ; push_rax                    # Protect the number of bytes read
 
 	4889C2                      ; mov_rdx,rax                 # Number of bytes to write
@@ -98,6 +102,12 @@
 	483D 00001000               ; cmp_rax, %0x100000          # Check if buffer was fully used
 	0F84 %keep                  ; je %keep                    # Keep looping if was full
 	E9 %core                    ; jmp %core                   # Otherwise move to next file
+
+:fail
+	# an input file could not be read
+	48C7C7 01000000             ; mov_rdi, %1                 # All is not well
+	48C7C0 3C000000             ; mov_rax, %0x3C              # put the exit syscall number in eax
+	0F05                        ; syscall                     # Call it a bad day
 
 :done
 	# program completed Successfully


### PR DESCRIPTION
`catm` never checks the result of `open()`, so a missing or unreadable input leaves the negative errno in the input fd register; `read()` then returns `-EBADF` and that value becomes the `write()` byte count, corrupting or silently truncating the output while `catm` still exits 0.

This adds a check after the input `open()` and after each `read()`, exiting 1 instead. Valid inputs still produce byte-identical output; both the GAS source and the hand-written seed encoding are updated.
